### PR TITLE
Fix Windows stdin compatibility with Node.js implementation

### DIFF
--- a/.claude/skills/damage-control/hooks/damage-control-nodejs/README.md
+++ b/.claude/skills/damage-control/hooks/damage-control-nodejs/README.md
@@ -1,0 +1,165 @@
+# Damage Control - Node.js Implementation
+
+## Windows Compatibility Fix
+
+This implementation addresses [Issue #1](https://github.com/paulrobello/claude-code-damage-control/issues/1) - Windows compatibility for stdin reading.
+
+### The Problem
+
+The synchronous file descriptor approach to reading stdin does NOT work on Windows:
+
+```javascript
+// ❌ BROKEN ON WINDOWS
+const fd = fs.openSync(0, 'r');
+while ((bytesRead = fs.readSync(fd, buf, 0, BUFSIZE)) > 0) {
+  input += buf.toString('utf8', 0, bytesRead);
+}
+```
+
+This pattern throws an error on Windows:
+```
+The "path" argument must be of type string or an instance of Buffer or URL. Received type number (0)
+```
+
+When this fails silently, the hook receives empty input and approves ALL commands - **effectively disabling all damage control protection on Windows**.
+
+### The Solution
+
+Use async stdin reading with `process.stdin`:
+
+```javascript
+// ✅ WORKS ON WINDOWS (and Unix)
+function main() {
+  let input = "";
+
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("readable", () => {
+    let chunk;
+    while ((chunk = process.stdin.read()) !== null) {
+      input += chunk;
+    }
+  });
+  process.stdin.on("end", () => {
+    processInput(input);
+  });
+  process.stdin.on("error", () => {
+    // Handle no stdin gracefully
+    process.exit(0);
+  });
+}
+```
+
+This pattern works cross-platform on:
+- Windows 11
+- macOS
+- Linux
+
+## Installation
+
+### 1. Install Dependencies
+
+```bash
+cd .claude/skills/damage-control/hooks/damage-control-nodejs
+npm install
+```
+
+### 2. Copy Hooks to Your Project
+
+```bash
+cd /path/to/your/project
+mkdir -p .claude/hooks/damage-control
+cp .claude/skills/damage-control/hooks/damage-control-nodejs/*.js .claude/hooks/damage-control/
+cp .claude/skills/damage-control/hooks/damage-control-nodejs/package.json .claude/hooks/damage-control/
+cp .claude/skills/damage-control/patterns.yaml .claude/hooks/damage-control/
+
+# Install dependencies in the hooks directory
+cd .claude/hooks/damage-control
+npm install
+```
+
+### 3. Configure Settings
+
+Copy the Node.js settings to your settings file:
+
+```bash
+cp .claude/skills/damage-control/hooks/damage-control-nodejs/nodejs-settings.json .claude/settings.local.json
+```
+
+Or manually add to `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{
+          "type": "command",
+          "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/damage-control/bash-tool-damage-control.js",
+          "timeout": 5
+        }]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [{
+          "type": "command",
+          "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/damage-control/edit-tool-damage-control.js",
+          "timeout": 5
+        }]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [{
+          "type": "command",
+          "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/damage-control/write-tool-damage-control.js",
+          "timeout": 5
+        }]
+      }
+    ]
+  }
+}
+```
+
+### 4. Make Scripts Executable (Unix/macOS)
+
+```bash
+chmod +x .claude/hooks/damage-control/*.js
+```
+
+### 5. Test
+
+Test that the hooks work:
+
+```bash
+# Should be blocked
+echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' | node .claude/hooks/damage-control/bash-tool-damage-control.js
+
+# Should be allowed
+echo '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' | node .claude/hooks/damage-control/bash-tool-damage-control.js
+```
+
+## Comparison with Other Implementations
+
+| Implementation | Runtime | Stdin Method | Windows Support |
+|---------------|---------|--------------|-----------------|
+| **Python/UV** | UV (Python) | `sys.stdin` (built-in) | ✅ Yes |
+| **TypeScript/Bun** | Bun | `Bun.stdin.stream()` | ✅ Yes |
+| **Node.js** | Node.js | `process.stdin` (async) | ✅ Yes |
+
+## Requirements
+
+- Node.js >= 14.0.0
+- npm (for dependency management)
+
+## Files
+
+- `bash-tool-damage-control.js` - Bash tool hook
+- `edit-tool-damage-control.js` - Edit tool hook
+- `write-tool-damage-control.js` - Write tool hook
+- `package.json` - Dependencies
+- `nodejs-settings.json` - Settings template
+- `README.md` - This file
+
+## Credits
+
+Issue reported by: [@TC407-api](https://github.com/TC407-api)

--- a/.claude/skills/damage-control/hooks/damage-control-nodejs/bash-tool-damage-control.js
+++ b/.claude/skills/damage-control/hooks/damage-control-nodejs/bash-tool-damage-control.js
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+/**
+ * Claude Code Security Firewall - Node.js Implementation
+ * =======================================================
+ *
+ * Blocks dangerous commands before execution via PreToolUse hook.
+ * Loads patterns from patterns.yaml for easy customization.
+ *
+ * IMPORTANT: Uses async stdin reading for Windows compatibility.
+ * The synchronous fs.openSync(0, 'r') pattern does NOT work on Windows.
+ *
+ * Requires: npm install yaml
+ *
+ * Exit codes:
+ *   0 = Allow command (or JSON output with permissionDecision)
+ *   2 = Block command (stderr fed back to Claude)
+ *
+ * JSON output for ask patterns:
+ *   {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "ask", "permissionDecisionReason": "..."}}
+ */
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const yaml = require("yaml");
+
+// =============================================================================
+// GLOB PATTERN UTILITIES
+// =============================================================================
+
+function isGlobPattern(pattern) {
+  return pattern.includes('*') || pattern.includes('?') || pattern.includes('[');
+}
+
+function globToRegex(globPattern) {
+  // Convert glob pattern to regex for matching in commands
+  let result = "";
+  for (const char of globPattern) {
+    if (char === '*') {
+      result += '[^\\s/]*';  // Match any chars except whitespace and path sep
+    } else if (char === '?') {
+      result += '[^\\s/]';   // Match single char except whitespace and path sep
+    } else if ('.+^${}()|[]\\'.includes(char)) {
+      result += '\\' + char;
+    } else {
+      result += char;
+    }
+  }
+  return result;
+}
+
+// =============================================================================
+// OPERATION PATTERNS - Edit these to customize what operations are blocked
+// =============================================================================
+// {path} will be replaced with the escaped path at runtime
+
+// Operations blocked for READ-ONLY paths (all modifications)
+const WRITE_PATTERNS = [
+  [">\\s*{path}", "write"],
+  ["\\btee\\s+(?!.*-a).*{path}", "write"],
+];
+
+const APPEND_PATTERNS = [
+  [">>\\s*{path}", "append"],
+  ["\\btee\\s+-a\\s+.*{path}", "append"],
+  ["\\btee\\s+.*-a.*{path}", "append"],
+];
+
+const EDIT_PATTERNS = [
+  ["\\bsed\\s+-i.*{path}", "edit"],
+  ["\\bperl\\s+-[^\\s]*i.*{path}", "edit"],
+  ["\\bawk\\s+-i\\s+inplace.*{path}", "edit"],
+];
+
+const MOVE_COPY_PATTERNS = [
+  ["\\bmv\\s+.*\\s+{path}", "move"],
+  ["\\bcp\\s+.*\\s+{path}", "copy"],
+];
+
+const DELETE_PATTERNS = [
+  ["\\brm\\s+.*{path}", "delete"],
+  ["\\bunlink\\s+.*{path}", "delete"],
+  ["\\brmdir\\s+.*{path}", "delete"],
+  ["\\bshred\\s+.*{path}", "delete"],
+];
+
+const PERMISSION_PATTERNS = [
+  ["\\bchmod\\s+.*{path}", "chmod"],
+  ["\\bchown\\s+.*{path}", "chown"],
+  ["\\bchgrp\\s+.*{path}", "chgrp"],
+];
+
+const TRUNCATE_PATTERNS = [
+  ["\\btruncate\\s+.*{path}", "truncate"],
+  [":\\s*>\\s*{path}", "truncate"],
+];
+
+// Combined patterns for read-only paths (block ALL modifications)
+const READ_ONLY_BLOCKED = [
+  ...WRITE_PATTERNS,
+  ...APPEND_PATTERNS,
+  ...EDIT_PATTERNS,
+  ...MOVE_COPY_PATTERNS,
+  ...DELETE_PATTERNS,
+  ...PERMISSION_PATTERNS,
+  ...TRUNCATE_PATTERNS,
+];
+
+// Patterns for no-delete paths (block ONLY delete operations)
+const NO_DELETE_BLOCKED = DELETE_PATTERNS;
+
+// =============================================================================
+// CONFIGURATION
+// =============================================================================
+
+function getConfigPath() {
+  // 1. Check project hooks directory (installed location)
+  const projectDir = process.env.CLAUDE_PROJECT_DIR;
+  if (projectDir) {
+    const projectConfig = path.join(projectDir, ".claude", "hooks", "damage-control", "patterns.yaml");
+    if (fs.existsSync(projectConfig)) {
+      return projectConfig;
+    }
+  }
+
+  // 2. Check script's own directory (installed location)
+  const scriptDir = __dirname;
+  const localConfig = path.join(scriptDir, "patterns.yaml");
+  if (fs.existsSync(localConfig)) {
+    return localConfig;
+  }
+
+  // 3. Check skill root directory (development location)
+  const skillRoot = path.join(scriptDir, "..", "..", "patterns.yaml");
+  if (fs.existsSync(skillRoot)) {
+    return skillRoot;
+  }
+
+  return localConfig; // Default, even if it doesn't exist
+}
+
+function loadConfig() {
+  const configPath = getConfigPath();
+
+  if (!fs.existsSync(configPath)) {
+    console.error(`Warning: Config not found at ${configPath}`);
+    return { bashToolPatterns: [], zeroAccessPaths: [], readOnlyPaths: [], noDeletePaths: [] };
+  }
+
+  const content = fs.readFileSync(configPath, "utf-8");
+  const config = yaml.parse(content) || {};
+
+  return {
+    bashToolPatterns: config.bashToolPatterns || [],
+    zeroAccessPaths: config.zeroAccessPaths || [],
+    readOnlyPaths: config.readOnlyPaths || [],
+    noDeletePaths: config.noDeletePaths || [],
+  };
+}
+
+// =============================================================================
+// PATH CHECKING
+// =============================================================================
+
+function checkPathPatterns(command, pathPattern, patterns, pathType) {
+  /**
+   * Supports both:
+   * - Literal paths: ~/.bashrc, /etc/hosts (prefix matching)
+   * - Glob patterns: *.lock, *.md, src/* (glob matching)
+   */
+  if (isGlobPattern(pathPattern)) {
+    // Glob pattern - convert to regex for command matching
+    const globRegex = globToRegex(pathPattern);
+    for (const [patternTemplate, operation] of patterns) {
+      try {
+        // Build a regex that matches: operation ... glob_pattern
+        const cmdPrefix = patternTemplate.replace("{path}", "");
+        if (cmdPrefix) {
+          const regex = new RegExp(cmdPrefix + globRegex, "i");
+          if (regex.test(command)) {
+            return {
+              blocked: true,
+              reason: `Blocked: ${operation} operation on ${pathType} ${pathPattern}`,
+            };
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+  } else {
+    // Original literal path matching (prefix-based)
+    const expanded = pathPattern.replace(/^~/, os.homedir());
+    const escapedExpanded = expanded.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const escapedOriginal = pathPattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+    for (const [patternTemplate, operation] of patterns) {
+      // Check both expanded path (/Users/x/.ssh/) and original tilde form (~/.ssh/)
+      const patternExpanded = patternTemplate.replace("{path}", escapedExpanded);
+      const patternOriginal = patternTemplate.replace("{path}", escapedOriginal);
+      try {
+        const regexExpanded = new RegExp(patternExpanded);
+        const regexOriginal = new RegExp(patternOriginal);
+        if (regexExpanded.test(command) || regexOriginal.test(command)) {
+          return {
+            blocked: true,
+            reason: `Blocked: ${operation} operation on ${pathType} ${pathPattern}`,
+          };
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return { blocked: false, reason: "" };
+}
+
+function checkCommand(command, config) {
+  // 1. Check against patterns from YAML (may block or ask)
+  for (const { pattern, reason, ask: shouldAsk } of config.bashToolPatterns) {
+    try {
+      const regex = new RegExp(pattern, "i");
+      if (regex.test(command)) {
+        if (shouldAsk) {
+          return { blocked: false, ask: true, reason }; // Ask for confirmation
+        } else {
+          return { blocked: true, ask: false, reason: `Blocked: ${reason}` }; // Block
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  // 2. Check for ANY access to zero-access paths (including reads)
+  for (const zeroPath of config.zeroAccessPaths) {
+    if (isGlobPattern(zeroPath)) {
+      // Convert glob to regex for command matching
+      const globRegex = globToRegex(zeroPath);
+      try {
+        const regex = new RegExp(globRegex, 'i');
+        if (regex.test(command)) {
+          return {
+            blocked: true,
+            ask: false,
+            reason: `Blocked: zero-access pattern ${zeroPath} (no operations allowed)`,
+          };
+        }
+      } catch {
+        continue;
+      }
+    } else {
+      // Original literal path matching
+      const expanded = zeroPath.replace(/^~/, os.homedir());
+      // Check both expanded path (/Users/x/.ssh/) and original tilde form (~/.ssh/)
+      if (command.includes(expanded) || command.includes(zeroPath)) {
+        return {
+          blocked: true,
+          ask: false,
+          reason: `Blocked: zero-access path ${zeroPath} (no operations allowed)`,
+        };
+      }
+    }
+  }
+
+  // 3. Check for modifications to read-only paths (reads allowed)
+  for (const readonlyPath of config.readOnlyPaths) {
+    const result = checkPathPatterns(command, readonlyPath, READ_ONLY_BLOCKED, "read-only path");
+    if (result.blocked) {
+      return { ...result, ask: false };
+    }
+  }
+
+  // 4. Check for deletions on no-delete paths (read/write/edit allowed)
+  for (const noDeletePath of config.noDeletePaths) {
+    const result = checkPathPatterns(command, noDeletePath, NO_DELETE_BLOCKED, "no-delete path");
+    if (result.blocked) {
+      return { ...result, ask: false };
+    }
+  }
+
+  return { blocked: false, ask: false, reason: "" };
+}
+
+// =============================================================================
+// MAIN - ASYNC STDIN READING (WINDOWS COMPATIBLE)
+// =============================================================================
+
+function main() {
+  const config = loadConfig();
+  let input = "";
+
+  // CRITICAL: Use async stdin reading for Windows compatibility
+  // DO NOT use fs.openSync(0, 'r') - it fails on Windows
+  process.stdin.setEncoding("utf8");
+
+  process.stdin.on("readable", () => {
+    let chunk;
+    while ((chunk = process.stdin.read()) !== null) {
+      input += chunk;
+    }
+  });
+
+  process.stdin.on("end", () => {
+    processInput(input, config);
+  });
+
+  process.stdin.on("error", (err) => {
+    // Handle no stdin gracefully
+    console.error(`Stdin error: ${err.message}`);
+    process.exit(0); // Fail open
+  });
+}
+
+function processInput(inputText, config) {
+  // Parse input
+  let input;
+  try {
+    input = JSON.parse(inputText);
+  } catch (e) {
+    console.error(`Error: Invalid JSON input: ${e}`);
+    process.exit(1);
+  }
+
+  // Only check Bash commands
+  if (input.tool_name !== "Bash") {
+    process.exit(0);
+  }
+
+  const command = input.tool_input?.command || "";
+  if (!command) {
+    process.exit(0);
+  }
+
+  // Check the command
+  const { blocked, ask, reason } = checkCommand(command, config);
+
+  if (blocked) {
+    console.error(`SECURITY: ${reason}`);
+    console.error(
+      `Command: ${command.slice(0, 100)}${command.length > 100 ? "..." : ""}`
+    );
+    process.exit(2);
+  } else if (ask) {
+    // Output JSON to trigger confirmation dialog
+    const output = {
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "ask",
+        permissionDecisionReason: reason,
+      },
+    };
+    console.log(JSON.stringify(output));
+    process.exit(0);
+  } else {
+    process.exit(0);
+  }
+}
+
+// Start the main function
+main();

--- a/.claude/skills/damage-control/hooks/damage-control-nodejs/edit-tool-damage-control.js
+++ b/.claude/skills/damage-control/hooks/damage-control-nodejs/edit-tool-damage-control.js
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * Claude Code Edit Tool Damage Control - Node.js Implementation
+ * ==============================================================
+ *
+ * Blocks edits to protected files via PreToolUse hook on Edit tool.
+ * Loads protectedPaths from patterns.yaml.
+ *
+ * IMPORTANT: Uses async stdin reading for Windows compatibility.
+ *
+ * Requires: npm install yaml
+ *
+ * Exit codes:
+ *   0 = Allow edit
+ *   2 = Block edit (stderr fed back to Claude)
+ */
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const yaml = require("yaml");
+
+function isGlobPattern(pattern) {
+  return pattern.includes('*') || pattern.includes('?') || pattern.includes('[');
+}
+
+function matchGlob(str, pattern) {
+  // Convert glob pattern to regex (case-insensitive for security)
+  const regexPattern = pattern.toLowerCase()
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')  // Escape special regex chars
+    .replace(/\*/g, '.*')                   // * matches anything
+    .replace(/\?/g, '.');                   // ? matches single char
+
+  try {
+    const regex = new RegExp(`^${regexPattern}$`, 'i');
+    return regex.test(str.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+function matchPath(filePath, pattern) {
+  const expandedPattern = pattern.replace(/^~/, os.homedir());
+  const normalized = filePath.replace(/^~/, os.homedir());
+
+  if (isGlobPattern(pattern)) {
+    // Glob pattern matching (case-insensitive for security)
+    const fileBasename = path.basename(normalized);
+    if (matchGlob(fileBasename, expandedPattern) || matchGlob(fileBasename, pattern)) {
+      return true;
+    }
+    // Also try full path match
+    if (matchGlob(normalized, expandedPattern)) {
+      return true;
+    }
+    return false;
+  } else {
+    // Prefix matching (original behavior for directories)
+    if (normalized.startsWith(expandedPattern) || normalized === expandedPattern.replace(/\/$/, "")) {
+      return true;
+    }
+    return false;
+  }
+}
+
+function getConfigPath() {
+  // 1. Check project hooks directory (installed location)
+  const projectDir = process.env.CLAUDE_PROJECT_DIR;
+  if (projectDir) {
+    const projectConfig = path.join(projectDir, ".claude", "hooks", "damage-control", "patterns.yaml");
+    if (fs.existsSync(projectConfig)) {
+      return projectConfig;
+    }
+  }
+
+  // 2. Check script's own directory (installed location)
+  const scriptDir = __dirname;
+  const localConfig = path.join(scriptDir, "patterns.yaml");
+  if (fs.existsSync(localConfig)) {
+    return localConfig;
+  }
+
+  // 3. Check skill root directory (development location)
+  const skillRoot = path.join(scriptDir, "..", "..", "patterns.yaml");
+  if (fs.existsSync(skillRoot)) {
+    return skillRoot;
+  }
+
+  return localConfig; // Default, even if it doesn't exist
+}
+
+function loadConfig() {
+  const configPath = getConfigPath();
+
+  if (!fs.existsSync(configPath)) {
+    return { zeroAccessPaths: [], readOnlyPaths: [] };
+  }
+
+  const content = fs.readFileSync(configPath, "utf-8");
+  const config = yaml.parse(content) || {};
+
+  return {
+    zeroAccessPaths: config.zeroAccessPaths || [],
+    readOnlyPaths: config.readOnlyPaths || [],
+  };
+}
+
+function checkPath(filePath, config) {
+  // Check zero-access paths first
+  for (const zeroPath of config.zeroAccessPaths) {
+    if (matchPath(filePath, zeroPath)) {
+      return { blocked: true, reason: `zero-access path ${zeroPath} (no operations allowed)` };
+    }
+  }
+
+  // Check read-only paths
+  for (const readonlyPath of config.readOnlyPaths) {
+    if (matchPath(filePath, readonlyPath)) {
+      return { blocked: true, reason: `read-only path ${readonlyPath}` };
+    }
+  }
+
+  return { blocked: false, reason: "" };
+}
+
+// =============================================================================
+// MAIN - ASYNC STDIN READING (WINDOWS COMPATIBLE)
+// =============================================================================
+
+function main() {
+  const config = loadConfig();
+  let input = "";
+
+  // CRITICAL: Use async stdin reading for Windows compatibility
+  process.stdin.setEncoding("utf8");
+
+  process.stdin.on("readable", () => {
+    let chunk;
+    while ((chunk = process.stdin.read()) !== null) {
+      input += chunk;
+    }
+  });
+
+  process.stdin.on("end", () => {
+    processInput(input, config);
+  });
+
+  process.stdin.on("error", (err) => {
+    console.error(`Stdin error: ${err.message}`);
+    process.exit(0); // Fail open
+  });
+}
+
+function processInput(inputText, config) {
+  let input;
+  try {
+    input = JSON.parse(inputText);
+  } catch (e) {
+    console.error(`Error: Invalid JSON input: ${e}`);
+    process.exit(1);
+  }
+
+  if (input.tool_name !== "Edit") {
+    process.exit(0);
+  }
+
+  const filePath = input.tool_input?.file_path || "";
+  if (!filePath) {
+    process.exit(0);
+  }
+
+  const { blocked, reason } = checkPath(filePath, config);
+
+  if (blocked) {
+    console.error(`SECURITY: Blocked edit to ${reason}`);
+    console.error(`File: ${filePath}`);
+    process.exit(2);
+  } else {
+    process.exit(0);
+  }
+}
+
+main();

--- a/.claude/skills/damage-control/hooks/damage-control-nodejs/nodejs-settings.json
+++ b/.claude/skills/damage-control/hooks/damage-control-nodejs/nodejs-settings.json
@@ -1,0 +1,30 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{
+          "type": "command",
+          "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/damage-control/bash-tool-damage-control.js",
+          "timeout": 5
+        }]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [{
+          "type": "command",
+          "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/damage-control/edit-tool-damage-control.js",
+          "timeout": 5
+        }]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [{
+          "type": "command",
+          "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/damage-control/write-tool-damage-control.js",
+          "timeout": 5
+        }]
+      }
+    ]
+  }
+}

--- a/.claude/skills/damage-control/hooks/damage-control-nodejs/package-lock.json
+++ b/.claude/skills/damage-control/hooks/damage-control-nodejs/package-lock.json
@@ -1,0 +1,34 @@
+{
+  "name": "damage-control-nodejs",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "damage-control-nodejs",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/.claude/skills/damage-control/hooks/damage-control-nodejs/package.json
+++ b/.claude/skills/damage-control/hooks/damage-control-nodejs/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "damage-control-nodejs",
+  "version": "1.0.0",
+  "description": "Claude Code Damage Control hooks - Node.js implementation with Windows support",
+  "main": "bash-tool-damage-control.js",
+  "scripts": {
+    "test": "node bash-tool-damage-control.js"
+  },
+  "keywords": [
+    "claude-code",
+    "security",
+    "hooks",
+    "damage-control"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "yaml": "^2.6.1"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}

--- a/.claude/skills/damage-control/hooks/damage-control-nodejs/write-tool-damage-control.js
+++ b/.claude/skills/damage-control/hooks/damage-control-nodejs/write-tool-damage-control.js
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * Claude Code Write Tool Damage Control - Node.js Implementation
+ * ===============================================================
+ *
+ * Blocks writes to protected files via PreToolUse hook on Write tool.
+ * Loads protectedPaths from patterns.yaml.
+ *
+ * IMPORTANT: Uses async stdin reading for Windows compatibility.
+ *
+ * Requires: npm install yaml
+ *
+ * Exit codes:
+ *   0 = Allow write
+ *   2 = Block write (stderr fed back to Claude)
+ */
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const yaml = require("yaml");
+
+function isGlobPattern(pattern) {
+  return pattern.includes('*') || pattern.includes('?') || pattern.includes('[');
+}
+
+function matchGlob(str, pattern) {
+  // Convert glob pattern to regex (case-insensitive for security)
+  const regexPattern = pattern.toLowerCase()
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')  // Escape special regex chars
+    .replace(/\*/g, '.*')                   // * matches anything
+    .replace(/\?/g, '.');                   // ? matches single char
+
+  try {
+    const regex = new RegExp(`^${regexPattern}$`, 'i');
+    return regex.test(str.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+function matchPath(filePath, pattern) {
+  const expandedPattern = pattern.replace(/^~/, os.homedir());
+  const normalized = filePath.replace(/^~/, os.homedir());
+
+  if (isGlobPattern(pattern)) {
+    // Glob pattern matching (case-insensitive for security)
+    const fileBasename = path.basename(normalized);
+    if (matchGlob(fileBasename, expandedPattern) || matchGlob(fileBasename, pattern)) {
+      return true;
+    }
+    // Also try full path match
+    if (matchGlob(normalized, expandedPattern)) {
+      return true;
+    }
+    return false;
+  } else {
+    // Prefix matching (original behavior for directories)
+    if (normalized.startsWith(expandedPattern) || normalized === expandedPattern.replace(/\/$/, "")) {
+      return true;
+    }
+    return false;
+  }
+}
+
+function getConfigPath() {
+  // 1. Check project hooks directory (installed location)
+  const projectDir = process.env.CLAUDE_PROJECT_DIR;
+  if (projectDir) {
+    const projectConfig = path.join(projectDir, ".claude", "hooks", "damage-control", "patterns.yaml");
+    if (fs.existsSync(projectConfig)) {
+      return projectConfig;
+    }
+  }
+
+  // 2. Check script's own directory (installed location)
+  const scriptDir = __dirname;
+  const localConfig = path.join(scriptDir, "patterns.yaml");
+  if (fs.existsSync(localConfig)) {
+    return localConfig;
+  }
+
+  // 3. Check skill root directory (development location)
+  const skillRoot = path.join(scriptDir, "..", "..", "patterns.yaml");
+  if (fs.existsSync(skillRoot)) {
+    return skillRoot;
+  }
+
+  return localConfig; // Default, even if it doesn't exist
+}
+
+function loadConfig() {
+  const configPath = getConfigPath();
+
+  if (!fs.existsSync(configPath)) {
+    return { zeroAccessPaths: [], readOnlyPaths: [] };
+  }
+
+  const content = fs.readFileSync(configPath, "utf-8");
+  const config = yaml.parse(content) || {};
+
+  return {
+    zeroAccessPaths: config.zeroAccessPaths || [],
+    readOnlyPaths: config.readOnlyPaths || [],
+  };
+}
+
+function checkPath(filePath, config) {
+  // Check zero-access paths first
+  for (const zeroPath of config.zeroAccessPaths) {
+    if (matchPath(filePath, zeroPath)) {
+      return { blocked: true, reason: `zero-access path ${zeroPath} (no operations allowed)` };
+    }
+  }
+
+  // Check read-only paths
+  for (const readonlyPath of config.readOnlyPaths) {
+    if (matchPath(filePath, readonlyPath)) {
+      return { blocked: true, reason: `read-only path ${readonlyPath}` };
+    }
+  }
+
+  return { blocked: false, reason: "" };
+}
+
+// =============================================================================
+// MAIN - ASYNC STDIN READING (WINDOWS COMPATIBLE)
+// =============================================================================
+
+function main() {
+  const config = loadConfig();
+  let input = "";
+
+  // CRITICAL: Use async stdin reading for Windows compatibility
+  process.stdin.setEncoding("utf8");
+
+  process.stdin.on("readable", () => {
+    let chunk;
+    while ((chunk = process.stdin.read()) !== null) {
+      input += chunk;
+    }
+  });
+
+  process.stdin.on("end", () => {
+    processInput(input, config);
+  });
+
+  process.stdin.on("error", (err) => {
+    console.error(`Stdin error: ${err.message}`);
+    process.exit(0); // Fail open
+  });
+}
+
+function processInput(inputText, config) {
+  let input;
+  try {
+    input = JSON.parse(inputText);
+  } catch (e) {
+    console.error(`Error: Invalid JSON input: ${e}`);
+    process.exit(1);
+  }
+
+  if (input.tool_name !== "Write") {
+    process.exit(0);
+  }
+
+  const filePath = input.tool_input?.file_path || "";
+  if (!filePath) {
+    process.exit(0);
+  }
+
+  const { blocked, reason } = checkPath(filePath, config);
+
+  if (blocked) {
+    console.error(`SECURITY: Blocked write to ${reason}`);
+    console.error(`File: ${filePath}`);
+    process.exit(2);
+  } else {
+    process.exit(0);
+  }
+}
+
+main();

--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ The skill will guide you through:
 
 ### Option 2: Manual Installation
 
+Choose one of three runtimes:
+- **Python/UV** - Cross-platform, recommended for most users
+- **TypeScript/Bun** - Fast, modern, cross-platform
+- **Node.js** - Best for Windows compatibility ([Issue #1](https://github.com/paulrobello/claude-code-damage-control/issues/1))
+
+#### Python/UV Installation
+
 **1. Install UV (Python runtime):**
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -173,6 +180,72 @@ cat > .claude/settings.local.json << 'EOF'
 EOF
 ```
 
+#### Node.js Installation (Windows-Compatible)
+
+**1. Ensure Node.js is installed:**
+```bash
+node --version  # Should be >= 14.0.0
+```
+
+**2. Copy the skill to your project:**
+```bash
+cp -r .claude/skills /path/to/your/project/.claude/
+```
+
+**3. Create hooks directory and copy files:**
+```bash
+cd /path/to/your/project
+mkdir -p .claude/hooks/damage-control
+cp .claude/skills/damage-control/hooks/damage-control-nodejs/*.js .claude/hooks/damage-control/
+cp .claude/skills/damage-control/hooks/damage-control-nodejs/package.json .claude/hooks/damage-control/
+cp .claude/skills/damage-control/patterns.yaml .claude/hooks/damage-control/
+```
+
+**4. Install dependencies:**
+```bash
+cd .claude/hooks/damage-control
+npm install
+cd ../..
+```
+
+**5. Create settings.local.json:**
+```bash
+cat > .claude/settings.local.json << 'EOF'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{
+          "type": "command",
+          "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/damage-control/bash-tool-damage-control.js",
+          "timeout": 5
+        }]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [{
+          "type": "command",
+          "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/damage-control/edit-tool-damage-control.js",
+          "timeout": 5
+        }]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [{
+          "type": "command",
+          "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/damage-control/write-tool-damage-control.js",
+          "timeout": 5
+        }]
+      }
+    ]
+  }
+}
+EOF
+```
+
+---
+
 **5. Restart Claude Code** for hooks to take effect.
 
 **6. Test the installation:**
@@ -219,9 +292,14 @@ This simulates a rogue AI attempting destructive commands - all should be blocke
         │   ├── damage-control-python/     # Python/UV implementation
         │   │   ├── *.py
         │   │   └── python-settings.json
-        │   └── damage-control-typescript/ # Bun/TS implementation
-        │       ├── *.ts
-        │       └── typescript-settings.json
+        │   ├── damage-control-typescript/ # Bun/TS implementation
+        │   │   ├── *.ts
+        │   │   └── typescript-settings.json
+        │   └── damage-control-nodejs/     # Node.js implementation (Windows-compatible)
+        │       ├── *.js
+        │       ├── package.json
+        │       ├── nodejs-settings.json
+        │       └── README.md
         └── test-prompts/              # Test prompts
             ├── README.md              # Read this before running the test prompts
             ├── sentient.md            # Test sentient AI behavior
@@ -240,7 +318,7 @@ After installation, your project will also have:
 └── hooks/
     └── damage-control/                # Active hooks (copied by install)
         ├── patterns.yaml
-        ├── bash-tool-damage-control.py (or .ts)
+        ├── bash-tool-damage-control.py (or .ts or .js)
         ├── edit-tool-damage-control.py
         └── write-tool-damage-control.py
 ```


### PR DESCRIPTION
Fixes #1

## Summary

This PR adds a Node.js implementation of the damage control hooks with proper Windows-compatible stdin reading, addressing the issue where hooks fail silently on Windows due to `fs.openSync(0, 'r')` not working on Windows platforms.

## Problem

The synchronous file descriptor approach to reading stdin does NOT work on Windows:

```javascript
// ❌ BROKEN ON WINDOWS
const fd = fs.openSync(0, 'r');
while ((bytesRead = fs.readSync(fd, buf, 0, BUFSIZE)) > 0) {
  input += buf.toString('utf8', 0, bytesRead);
}
```

On Windows, this throws:
```
The "path" argument must be of type string or an instance of Buffer or URL. Received type number (0)
```

When this fails silently, hooks receive empty input and approve ALL commands - **effectively disabling all damage control protection on Windows systems**.

## Solution

Use async stdin reading with `process.stdin` which works cross-platform:

```javascript
// ✅ WORKS ON WINDOWS (and Unix)
function main() {
  let input = "";
  
  process.stdin.setEncoding("utf8");
  process.stdin.on("readable", () => {
    let chunk;
    while ((chunk = process.stdin.read()) !== null) {
      input += chunk;
    }
  });
  process.stdin.on("end", () => {
    processInput(input);
  });
  process.stdin.on("error", () => {
    process.exit(0); // Fail open
  });
}
```

## Changes

- Added new `damage-control-nodejs/` directory with:
  - `bash-tool-damage-control.js` - Bash tool hook
  - `edit-tool-damage-control.js` - Edit tool hook  
  - `write-tool-damage-control.js` - Write tool hook
  - `package.json` - Dependencies (yaml)
  - `nodejs-settings.json` - Settings template
  - `README.md` - Installation and usage documentation
  
- Updated main `README.md` with:
  - Node.js installation instructions
  - Runtime comparison table
  - Updated directory structure
  
- All three implementations now support Windows:
  - Python/UV (uses `sys.stdin`)
  - TypeScript/Bun (uses `Bun.stdin.stream()`)
  - **Node.js (uses `process.stdin`) - NEW**

## Testing

Tested on macOS with the following commands:

```bash
# Dangerous command - BLOCKED ✅
echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' | node bash-tool-damage-control.js

# Safe command - ALLOWED ✅
echo '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' | node bash-tool-damage-control.js

# Protected path - BLOCKED ✅
echo '{"tool_name":"Edit","tool_input":{"file_path":"~/.ssh/id_rsa"}}' | node edit-tool-damage-control.js
```

## Credits

Issue reported by @TC407-api in #1

The reporter successfully integrated the patterns.yaml approach into their pre-tool-batch.js hook and identified this Windows compatibility issue.