### PR TITLE
Add Read tool hook to block reads from zeroAccessPaths

### DIFF
--- a/.claude/skills/damage-control/hooks/damage-control-python/bash-tool-damage-control.py
+++ b/.claude/skills/damage-control/hooks/damage-control-python/bash-tool-damage-control.py
@@ -183,7 +183,8 @@ def check_path_patterns(command: str, path: str, patterns: List[Tuple[str, str]]
             pattern_expanded = pattern_template.replace("{path}", escaped_expanded)
             pattern_original = pattern_template.replace("{path}", escaped_original)
             try:
-                if re.search(pattern_expanded, command) or re.search(pattern_original, command):
+                # Case-insensitive for security on case-insensitive filesystems like macOS
+                if re.search(pattern_expanded, command, re.IGNORECASE) or re.search(pattern_original, command, re.IGNORECASE):
                     return True, f"Blocked: {operation} operation on {path_type} {path}"
             except re.error:
                 continue
@@ -236,7 +237,8 @@ def check_command(command: str, config: Dict[str, Any]) -> Tuple[bool, bool, str
             escaped_original = re.escape(zero_path)
 
             # Check both expanded path (/Users/x/.ssh/) and original tilde form (~/.ssh/)
-            if re.search(escaped_expanded, command) or re.search(escaped_original, command):
+            # Case-insensitive for security on case-insensitive filesystems like macOS
+            if re.search(escaped_expanded, command, re.IGNORECASE) or re.search(escaped_original, command, re.IGNORECASE):
                 return True, False, f"Blocked: zero-access path {zero_path} (no operations allowed)"
 
     # 3. Check for modifications to read-only paths (reads allowed)

--- a/.claude/skills/damage-control/hooks/damage-control-python/edit-tool-damage-control.py
+++ b/.claude/skills/damage-control/hooks/damage-control-python/edit-tool-damage-control.py
@@ -52,8 +52,10 @@ def match_path(file_path: str, pattern: str) -> bool:
             return True
         return False
     else:
-        # Prefix matching (original behavior for directories)
-        if expanded_normalized.startswith(expanded_pattern) or expanded_normalized == expanded_pattern.rstrip('/'):
+        # Prefix matching (case-insensitive for security on case-insensitive filesystems like macOS)
+        expanded_normalized_lower = expanded_normalized.lower()
+        expanded_pattern_lower = expanded_pattern.lower()
+        if expanded_normalized_lower.startswith(expanded_pattern_lower) or expanded_normalized_lower == expanded_pattern_lower.rstrip('/'):
             return True
         return False
 

--- a/.claude/skills/damage-control/hooks/damage-control-python/python-settings.json
+++ b/.claude/skills/damage-control/hooks/damage-control-python/python-settings.json
@@ -35,6 +35,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/damage-control/read-tool-damage-control.py",
+            "timeout": 5
+          }
+        ]
       }
     ]
   },

--- a/.claude/skills/damage-control/hooks/damage-control-python/read-tool-damage-control.py
+++ b/.claude/skills/damage-control/hooks/damage-control-python/read-tool-damage-control.py
@@ -52,8 +52,10 @@ def match_path(file_path: str, pattern: str) -> bool:
             return True
         return False
     else:
-        # Prefix matching (original behavior for directories)
-        if expanded_normalized.startswith(expanded_pattern) or expanded_normalized == expanded_pattern.rstrip('/'):
+        # Prefix matching (case-insensitive for security on case-insensitive filesystems like macOS)
+        expanded_normalized_lower = expanded_normalized.lower()
+        expanded_pattern_lower = expanded_pattern.lower()
+        if expanded_normalized_lower.startswith(expanded_pattern_lower) or expanded_normalized_lower == expanded_pattern_lower.rstrip('/'):
             return True
         return False
 

--- a/.claude/skills/damage-control/hooks/damage-control-python/read-tool-damage-control.py
+++ b/.claude/skills/damage-control/hooks/damage-control-python/read-tool-damage-control.py
@@ -1,0 +1,138 @@
+# /// script
+# requires-python = ">=3.8"
+# dependencies = ["pyyaml"]
+# ///
+"""
+Claude Code Read Tool Damage Control
+=====================================
+
+Blocks reads from protected files via PreToolUse hook on Read tool.
+Loads zeroAccessPaths from patterns.yaml (readOnlyPaths allow reads).
+
+Exit codes:
+  0 = Allow read
+  2 = Block read (stderr fed back to Claude)
+"""
+
+import json
+import sys
+import os
+import fnmatch
+from pathlib import Path
+from typing import Dict, Any, Tuple
+
+import yaml
+
+
+def is_glob_pattern(pattern: str) -> bool:
+    """Check if pattern contains glob wildcards."""
+    return '*' in pattern or '?' in pattern or '[' in pattern
+
+
+def match_path(file_path: str, pattern: str) -> bool:
+    """Match file path against pattern, supporting both prefix and glob matching."""
+    expanded_pattern = os.path.expanduser(pattern)
+    normalized = os.path.normpath(file_path)
+    expanded_normalized = os.path.expanduser(normalized)
+
+    if is_glob_pattern(pattern):
+        # Glob pattern matching (case-insensitive for security)
+        basename = os.path.basename(expanded_normalized)
+        basename_lower = basename.lower()
+        pattern_lower = pattern.lower()
+        expanded_pattern_lower = expanded_pattern.lower()
+
+        # Match against basename for patterns like *.pem, .env*
+        if fnmatch.fnmatch(basename_lower, expanded_pattern_lower):
+            return True
+        if fnmatch.fnmatch(basename_lower, pattern_lower):
+            return True
+        # Also try full path match for patterns like /path/*.pem
+        if fnmatch.fnmatch(expanded_normalized.lower(), expanded_pattern_lower):
+            return True
+        return False
+    else:
+        # Prefix matching (original behavior for directories)
+        if expanded_normalized.startswith(expanded_pattern) or expanded_normalized == expanded_pattern.rstrip('/'):
+            return True
+        return False
+
+
+def get_config_path() -> Path:
+    """Get path to patterns.yaml, checking multiple locations."""
+    # 1. Check project hooks directory (installed location)
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
+    if project_dir:
+        project_config = Path(project_dir) / ".claude" / "hooks" / "damage-control" / "patterns.yaml"
+        if project_config.exists():
+            return project_config
+
+    # 2. Check script's own directory (installed location)
+    script_dir = Path(__file__).parent
+    local_config = script_dir / "patterns.yaml"
+    if local_config.exists():
+        return local_config
+
+    # 3. Check skill root directory (development location)
+    skill_root = script_dir.parent.parent / "patterns.yaml"
+    if skill_root.exists():
+        return skill_root
+
+    return local_config  # Default, even if it doesn't exist
+
+
+def load_config() -> Dict[str, Any]:
+    """Load config from YAML."""
+    config_path = get_config_path()
+
+    if not config_path.exists():
+        return {"zeroAccessPaths": []}
+
+    with open(config_path, "r") as f:
+        config = yaml.safe_load(f) or {}
+
+    return config
+
+
+def check_path(file_path: str, config: Dict[str, Any]) -> Tuple[bool, str]:
+    """Check if file_path is blocked for reading. Returns (blocked, reason)."""
+    # Only check zero-access paths (readOnlyPaths allow reads)
+    for zero_path in config.get("zeroAccessPaths", []):
+        if match_path(file_path, zero_path):
+            return True, f"zero-access path {zero_path} (no operations allowed)"
+
+    return False, ""
+
+
+def main() -> None:
+    config = load_config()
+
+    # Read hook input from stdin
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+
+    # Only check Read tool
+    if tool_name != "Read":
+        sys.exit(0)
+
+    file_path = tool_input.get("file_path", "") or tool_input.get("filePath", "")
+    if not file_path:
+        sys.exit(0)
+
+    # Check if file is blocked
+    blocked, reason = check_path(file_path, config)
+    if blocked:
+        print(f"SECURITY: Blocked read from {reason}: {file_path}", file=sys.stderr)
+        sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/damage-control/hooks/damage-control-python/write-tool-damage-control.py
+++ b/.claude/skills/damage-control/hooks/damage-control-python/write-tool-damage-control.py
@@ -52,8 +52,10 @@ def match_path(file_path: str, pattern: str) -> bool:
             return True
         return False
     else:
-        # Prefix matching (original behavior for directories)
-        if expanded_normalized.startswith(expanded_pattern) or expanded_normalized == expanded_pattern.rstrip('/'):
+        # Prefix matching (case-insensitive for security on case-insensitive filesystems like macOS)
+        expanded_normalized_lower = expanded_normalized.lower()
+        expanded_pattern_lower = expanded_pattern.lower()
+        if expanded_normalized_lower.startswith(expanded_pattern_lower) or expanded_normalized_lower == expanded_pattern_lower.rstrip('/'):
             return True
         return False
 


### PR DESCRIPTION
## Summary
- Added `read-tool-damage-control.py` hook to block Read tool access to sensitive paths
- Updated `python-settings.json` to register the Read tool hook matcher
- Fixed case sensitivity bypass vulnerability in ALL hooks (read, write, edit, bash)

## Root Cause
1. **Missing Read hook**: The damage control system had hooks for `Bash`, `Edit`, and `Write` tools but **the `Read` tool had no protection**, allowing Claude to directly read sensitive files.

2. **Case sensitivity bypass**: All hooks used case-sensitive path matching, but macOS (and some other systems) have case-insensitive filesystems. Attackers could bypass protection by using uppercase paths (e.g., `.SSH` instead of `.ssh`).

## Fix
1. **Added Read hook** (`read-tool-damage-control.py`):
   - Blocks reads from all paths in `zeroAccessPaths`
   - Allows reads from `readOnlyPaths` (as intended)

2. **Case-insensitive matching** in all hooks:
   - `read-tool`: prefix matching now uses `.lower()`
   - `write-tool`: prefix matching now uses `.lower()`
   - `edit-tool`: prefix matching now uses `.lower()`
   - `bash-tool`: regex matching now uses `re.IGNORECASE`

## Test Case

**Test damage control plugin by reading ~/.ssh/id_rsa:**
```
You: "Read ~/.ssh/id_rsa"
Claude attempts: Read tool with file_path: /Users/username/.ssh/id_rsa
Result: SECURITY: Blocked read from zero-access path ~/.ssh/ (no operations allowed)
```

**Test case sensitivity bypass is fixed:**
```
You: "Read ~/.SSH/id_rsa"  (uppercase SSH)
Result: SECURITY: Blocked read from zero-access path ~/.ssh/ (no operations allowed)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
